### PR TITLE
Fixing audio compatibility issues with windows

### DIFF
--- a/8Tunes/8Tunes.cbp
+++ b/8Tunes/8Tunes.cbp
@@ -25,6 +25,7 @@
 					<Add option="-march=corei7-avx" />
 					<Add option="-fomit-frame-pointer" />
 					<Add option="-fexpensive-optimizations" />
+					<Add option="-DRETRO_AUDIO_DEBUG" />
 					<Add directory="include" />
 				</Compiler>
 				<Linker>

--- a/8Tunes/8Tunes.depend
+++ b/8Tunes/8Tunes.depend
@@ -6,6 +6,8 @@
 	"DummyPPU.h"
 	<unistd.h>
 
+1583717350 
+
 1517460136 source:/home/alaix/git/O-Nes-Sama-apu/APU.cpp
 	"APU.h"
 
@@ -15,6 +17,8 @@
 	"Cartridge/Mappers/MemoryMapper.h"
 	"RetroAudio.hpp"
 
+1583716983 o.hpp"
+
 1495687942 /home/alaix/git/O-Nes-Sama-apu/CPUIO.hpp
 
 1499399848 /home/alaix/git/O-Nes-Sama-apu/Cartridge/Mappers/MemoryMapper.h
@@ -22,9 +26,13 @@
 	"../../CPUIO.hpp"
 	"../CartDB.hpp"
 
+1583717142 .hpp"
+
 1495687942 /home/alaix/git/O-Nes-Sama-apu/Cartridge/CartIO.hpp
 	<stdio.h>
 	"../CPUIO.hpp"
+
+1583649227 hpp"
 
 1495687942 /home/alaix/git/O-Nes-Sama-apu/Cartridge/CartDB.hpp
 
@@ -36,6 +44,8 @@
 	<iostream>
 	"opcodes.inc"
 
+1583713549 nc"
+
 1509065571 /home/alaix/git/O-Nes-Sama-apu/CPU.h
 	"Cartridge/Mappers/MemoryMapper.h"
 	"Logging/CPULogger.h"
@@ -45,6 +55,8 @@
 	"PPU.h"
 	"APU.h"
 	"CPUIO.hpp"
+
+1583649227 "
 
 1495687942 /home/alaix/git/O-Nes-Sama-apu/Logging/CPULogger.h
 	"Logger.h"
@@ -58,6 +70,8 @@
 	<stdexcept>
 	<regex>
 	<map>
+
+1583649211 >
 
 1509068996 /home/alaix/git/O-Nes-Sama-apu/CPUSharedData.h
 
@@ -79,6 +93,8 @@
 	"Cartridge/Cartridge.hpp"
 	"Logging/Logger.h"
 
+1583649218 ogger.h"
+
 1495687942 /home/alaix/git/O-Nes-Sama-apu/RetroGraphix/GraphixEngine.hpp
 	<stdio.h>
 	<SDL2/SDL.h>
@@ -96,6 +112,8 @@
 	<cstddef>
 	<SDL2/SDL.h>
 	"GraphixEngine.hpp"
+
+1583649227 gine.hpp"
 
 1495687942 /home/alaix/git/O-Nes-Sama-apu/RetroGraphix/Sprite.hpp
 	<SDL2/SDL.h>
@@ -131,14 +149,20 @@
 1524195397 source:/home/alaix/git/O-Nes-Sama-apu/8Tunes/NSFLoader.cpp
 	"NSFLoader.h"
 
+1583716945 .h"
+
 1514950928 /home/alaix/git/O-Nes-Sama-apu/8Tunes/NSFLoader.h
 	<cstdio>
 	"NSFMapper.hpp"
 	"../CPU.h"
 	"../RetroAudio.hpp"
 
+1583649155 udio.hpp"
+
 1495687942 source:/home/alaix/git/O-Nes-Sama-apu/Cartridge/Mappers/MemoryMapper.cpp
 	"MemoryMapper.h"
+
+1583649189 per.h"
 
 1518386663 source:/home/alaix/git/O-Nes-Sama-apu/RetroAudio.cpp
 	"RetroAudio.hpp"
@@ -295,5 +319,155 @@
 	"RetroAudio.hpp"
 
 1583717142 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/NSFMapper.cpp
+	"NSFMapper.hpp"
+
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/APU.cpp
+	"APU.h"
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/APU.h
+	<cstdio>
+	"CPUIO.hpp"
+	"Cartridge/Mappers/MemoryMapper.h"
+	"RetroAudio.hpp"
+
+1583649168 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPUIO.hpp
+
+1583649189 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Cartridge/Mappers/MemoryMapper.h
+	"../CartIO.hpp"
+	"../../CPUIO.hpp"
+	"../CartDB.hpp"
+
+1583649173 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Cartridge/CartIO.hpp
+	<stdio.h>
+	"../CPUIO.hpp"
+
+1583649171 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Cartridge/CartDB.hpp
+
+1591590624 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroAudio.hpp
+	<SDL2/SDL.h>
+	<queue>
+	<vector>
+	<stdio.h>
+
+1583649189 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Cartridge/Mappers/MemoryMapper.cpp
+	"MemoryMapper.h"
+
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPU.cpp
+	"CPU.h"
+	<stdio.h>
+	<fstream>
+	<stdlib.h>
+	<iostream>
+	"opcodes.inc"
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPU.h
+	"Cartridge/Mappers/MemoryMapper.h"
+	"Logging/CPULogger.h"
+	"8Tunes/DummyInput.h"
+	"8Tunes/DummyPPU.h"
+	"Input.h"
+	"PPU.h"
+	"APU.h"
+	"CPUIO.hpp"
+
+1583649211 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Logging/CPULogger.h
+	"Logger.h"
+	"../CPUSharedData.h"
+	"../CPUIO.hpp"
+
+1583649211 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Logging/Logger.h
+	<iostream>
+	<fstream>
+	<cstdarg>
+	<stdexcept>
+	<regex>
+	<map>
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPUSharedData.h
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/DummyInput.h
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/DummyPPU.h
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Input.h
+	<SDL2/SDL.h>
+	"CPUIO.hpp"
+
+1583649218 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/PPU.h
+	<unordered_map>
+	<functional>
+	<vector>
+	<cstring>
+	"CPUIO.hpp"
+	"RetroGraphix/GraphixEngine.hpp"
+	"RetroGraphix/Texture.hpp"
+	"RetroGraphix/Color.hpp"
+	"RetroGraphix/Sprite.hpp"
+	"Debugger/Breakpoint.h"
+	"Cartridge/Cartridge.hpp"
+	"Logging/Logger.h"
+
+1583649227 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/GraphixEngine.hpp
+	<stdio.h>
+	<SDL2/SDL.h>
+	"Drawable.hpp"
+	"Color.hpp"
+
+1583649227 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/Drawable.hpp
+
+1583649227 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/Color.hpp
+	<cinttypes>
+	<SDL2/SDL.h>
+	<stdio.h>
+
+1583649227 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/Texture.hpp
+	<cstddef>
+	<SDL2/SDL.h>
+	"GraphixEngine.hpp"
+
+1583649227 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/Sprite.hpp
+	<SDL2/SDL.h>
+	"Texture.hpp"
+	"GraphixEngine.hpp"
+	"Drawable.hpp"
+
+1583649192 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Debugger/Breakpoint.h
+	<stdio.h>
+	<string>
+	<vector>
+
+1583649175 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Cartridge/Cartridge.hpp
+	"CartIO.hpp"
+	"Mappers/MemoryMapper.h"
+	<string>
+	"zlib.h"
+
+1583649227 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/opcodes.inc
+
+1591590988 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroAudio.cpp
+	"RetroAudio.hpp"
+
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/8Tunes.cpp
+	<iostream>
+	"NSFLoader.h"
+	"../CPU.h"
+	"DummyPPU.h"
+	<unistd.h>
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/NSFLoader.h
+	<cstdio>
+	"NSFMapper.hpp"
+	"../CPU.h"
+	"../RetroAudio.hpp"
+
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/NSFMapper.hpp
+	"../Cartridge/Mappers/MemoryMapper.h"
+	"../Cartridge/CartIO.hpp"
+	"../CPU.h"
+
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/NSFLoader.cpp
+	"NSFLoader.h"
+
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/NSFMapper.cpp
 	"NSFMapper.hpp"
 

--- a/8Tunes/8Tunes.layout
+++ b/8Tunes/8Tunes.layout
@@ -2,9 +2,19 @@
 <CodeBlocks_layout_file>
 	<FileVersion major="1" minor="0" />
 	<ActiveTarget name="Release" />
-	<File name="NSFMapper.hpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="../CPU.cpp" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="97" topLine="0" />
+			<Cursor1 position="8795" topLine="270" />
+		</Cursor>
+	</File>
+	<File name="NSFLoader.cpp" open="1" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="207" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="../opcodes.inc" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7501" topLine="283" />
 		</Cursor>
 	</File>
 	<File name="NSFMapper.cpp" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -12,9 +22,24 @@
 			<Cursor1 position="1736" topLine="58" />
 		</Cursor>
 	</File>
-	<File name="../RetroAudio.hpp" open="1" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="NSFLoader.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="962" topLine="32" />
+			<Cursor1 position="152" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="8Tunes.cpp" open="1" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="345" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="../Cartridge/Mappers/MemoryMapper.h" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="64" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="../Cartridge/CartIO.hpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1847" topLine="63" />
 		</Cursor>
 	</File>
 	<File name="DummyPPU.h" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -27,34 +52,9 @@
 			<Cursor1 position="155" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="../APU.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="../CPUSharedData.h" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1317" topLine="105" />
-		</Cursor>
-	</File>
-	<File name="8Tunes.cpp" open="1" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="345" topLine="3" />
-		</Cursor>
-	</File>
-	<File name="../Cartridge/CartIO.hpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1847" topLine="63" />
-		</Cursor>
-	</File>
-	<File name="../opcodes.inc" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7501" topLine="283" />
-		</Cursor>
-	</File>
-	<File name="../RetroAudio.cpp" open="1" top="1" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="28" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="../Cartridge/Mappers/MemoryMapper.h" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="64" topLine="0" />
+			<Cursor1 position="708" topLine="17" />
 		</Cursor>
 	</File>
 	<File name="../APU.h" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -62,14 +62,9 @@
 			<Cursor1 position="238" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="NSFLoader.cpp" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="../RetroAudio.hpp" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="4647" topLine="139" />
-		</Cursor>
-	</File>
-	<File name="NSFLoader.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="152" topLine="27" />
+			<Cursor1 position="1165" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="../CPUIO.hpp" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -77,19 +72,24 @@
 			<Cursor1 position="165" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="../CPUSharedData.h" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="NSFMapper.hpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="708" topLine="17" />
+			<Cursor1 position="97" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="../RetroAudio.cpp" open="1" top="1" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1785" topLine="24" />
+		</Cursor>
+	</File>
+	<File name="../APU.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1317" topLine="105" />
 		</Cursor>
 	</File>
 	<File name="../CPU.h" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="569" topLine="12" />
-		</Cursor>
-	</File>
-	<File name="../CPU.cpp" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="8795" topLine="270" />
 		</Cursor>
 	</File>
 </CodeBlocks_layout_file>

--- a/O_Nes_Sama.depend
+++ b/O_Nes_Sama.depend
@@ -1108,10 +1108,10 @@
 1518386663 source:/home/alaix/git/O-Nes-Sama-apu/RetroAudio.cpp
 	"RetroAudio.hpp"
 
-1583716444 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/APU.cpp
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/APU.cpp
 	"APU.h"
 
-1517461652 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/APU.h
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/APU.h
 	<cstdio>
 	"CPUIO.hpp"
 	"Cartridge/Mappers/MemoryMapper.h"
@@ -1130,10 +1130,11 @@
 
 1583649171 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Cartridge/CartDB.hpp
 
-1583717350 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroAudio.hpp
+1591590624 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroAudio.hpp
 	<SDL2/SDL.h>
 	<queue>
 	<vector>
+	<stdio.h>
 
 1583649174 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Cartridge/Cartridge.cpp
 	"Cartridge.hpp"
@@ -1212,7 +1213,7 @@
 	"UxROM.hpp"
 	<stdio.h>
 
-1583713549 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPU.cpp
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPU.cpp
 	"CPU.h"
 	<stdio.h>
 	<fstream>
@@ -1220,7 +1221,7 @@
 	<iostream>
 	"opcodes.inc"
 
-1583716365 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPU.h
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPU.h
 	"Cartridge/Mappers/MemoryMapper.h"
 	"Logging/CPULogger.h"
 	"8Tunes/DummyInput.h"
@@ -1243,13 +1244,13 @@
 	<regex>
 	<map>
 
-1583649169 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPUSharedData.h
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/CPUSharedData.h
 
-1583649147 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/DummyInput.h
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/DummyInput.h
 
-1583649152 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/DummyPPU.h
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/8Tunes/DummyPPU.h
 
-1583649211 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Input.h
+1583717831 /home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Input.h
 	<SDL2/SDL.h>
 	"CPUIO.hpp"
 
@@ -1322,7 +1323,7 @@
 1583649195 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Debugger/SocketServer.cpp
 	"SocketServer.h"
 
-1583649211 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Input.cpp
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Input.cpp
 	"Input.h"
 
 1583649211 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/Logging/CPULogger.cpp
@@ -1338,13 +1339,13 @@
 1583649218 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/PPU.cpp
 	"PPU.h"
 
-1583717350 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroAudio.cpp
+1591591282 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroAudio.cpp
 	"RetroAudio.hpp"
 
 1583649227 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/Color.cpp
 	"Color.hpp"
 
-1583649227 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/GraphixEngine.cpp
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/GraphixEngine.cpp
 	"GraphixEngine.hpp"
 
 1583649227 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/Sprite.cpp
@@ -1353,7 +1354,7 @@
 1583649227 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/RetroGraphix/Texture.cpp
 	"Texture.hpp"
 
-1583714013 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/main.cpp
+1583717831 source:/home/walkerian/cpppy/cpp/O-Nes-Sama-apu/main.cpp
 	<stdio.h>
 	"Cartridge/Cartridge.hpp"
 	"CPU.h"

--- a/O_Nes_Sama.layout
+++ b/O_Nes_Sama.layout
@@ -2,109 +2,24 @@
 <CodeBlocks_layout_file>
 	<FileVersion major="1" minor="0" />
 	<ActiveTarget name="Release" />
-	<File name="Cartridge/Mappers/BasicMapper.hpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="543" topLine="3" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Mappers/BasicMapper.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="751" topLine="33" />
-		</Cursor>
-	</File>
-	<File name="RetroGraphix/GraphixEngine.hpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="0" topLine="8" />
-		</Cursor>
-	</File>
-	<File name="RetroAudio.hpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1001" topLine="27" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Mappers/UxROM.cpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="935" topLine="5" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Mappers/AxROM.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="429" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Cartridge.hpp" open="0" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="185" topLine="4" />
-		</Cursor>
-	</File>
-	<File name="Input.cpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1636" topLine="56" />
-		</Cursor>
-	</File>
-	<File name="main.cpp" open="1" top="1" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="729" topLine="17" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Cartridge.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4984" topLine="148" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/CartDB.hpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="312" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Logging/CPULogger.h" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="283" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="CPU.h" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4237" topLine="133" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Mappers/MMC2_4.hpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="394" topLine="1" />
-		</Cursor>
-	</File>
-	<File name="RetroGraphix/GraphixEngine.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="406" topLine="30" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Mappers/MMC3.hpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="184" topLine="2" />
-		</Cursor>
-	</File>
-	<File name="APU.h" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="213" topLine="87" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/CartIO.hpp" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="403" topLine="16" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Mappers/MMC1.hpp" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="312" topLine="0" />
-		</Cursor>
-	</File>
 	<File name="Cartridge/Mappers/MMC1.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="5153" topLine="126" />
 		</Cursor>
 	</File>
-	<File name="Logging/CPULogger.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Cartridge/Cartridge.hpp" open="1" top="1" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="7501" topLine="131" />
+			<Cursor1 position="294" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/MemoryMapper.cpp" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="0" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="PPU.cpp" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="28335" topLine="33" />
 		</Cursor>
 	</File>
 	<File name="Cartridge/Mappers/GxROM.hpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -112,19 +27,14 @@
 			<Cursor1 position="248" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="CPU.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Cartridge/Cartridge.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="4105" topLine="337" />
+			<Cursor1 position="4984" topLine="148" />
 		</Cursor>
 	</File>
-	<File name="Cartridge/Mappers/UxROM.hpp" open="0" top="0" tabpos="17" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Cartridge/Mappers/MMC2_4.hpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="271" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Cartridge/Mappers/GxROM.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="44" topLine="0" />
+			<Cursor1 position="394" topLine="1" />
 		</Cursor>
 	</File>
 	<File name="Cartridge/Mappers/MMC2_4.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -142,29 +52,34 @@
 			<Cursor1 position="4082" topLine="117" />
 		</Cursor>
 	</File>
-	<File name="Cartridge/Mappers/MemoryMapper.h" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="RetroGraphix/GraphixEngine.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="271" topLine="0" />
+			<Cursor1 position="406" topLine="30" />
 		</Cursor>
 	</File>
-	<File name="Cartridge/Mappers/MemoryMapper.cpp" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Cartridge/Mappers/BasicMapper.cpp" open="0" top="0" tabpos="18" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="0" topLine="0" />
+			<Cursor1 position="751" topLine="33" />
 		</Cursor>
 	</File>
-	<File name="PPU.h" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="CPU.h" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1999" topLine="163" />
+			<Cursor1 position="4237" topLine="133" />
 		</Cursor>
 	</File>
-	<File name="Cartridge/Mappers/CNROM.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Cartridge/Mappers/MMC1.hpp" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="41" topLine="0" />
+			<Cursor1 position="312" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="Cartridge/Mappers/MMC3.cpp" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="main.cpp" open="1" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="4090" topLine="110" />
+			<Cursor1 position="729" topLine="17" />
+		</Cursor>
+	</File>
+	<File name="RetroGraphix/GraphixEngine.hpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="0" topLine="8" />
 		</Cursor>
 	</File>
 	<File name="Debugger/Debugger.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -172,9 +87,9 @@
 			<Cursor1 position="2577" topLine="79" />
 		</Cursor>
 	</File>
-	<File name="Input.h" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Cartridge/Mappers/CNROM.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="281" topLine="3" />
+			<Cursor1 position="41" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="CPUSharedData.h" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -182,9 +97,94 @@
 			<Cursor1 position="800" topLine="16" />
 		</Cursor>
 	</File>
-	<File name="PPU.cpp" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="CPU.cpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="28335" topLine="33" />
+			<Cursor1 position="4105" topLine="337" />
+		</Cursor>
+	</File>
+	<File name="Input.h" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="281" topLine="3" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/AxROM.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="429" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/MMC3.hpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="184" topLine="2" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/UxROM.cpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="935" topLine="5" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/CartIO.hpp" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="403" topLine="16" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/MMC3.cpp" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4090" topLine="110" />
+		</Cursor>
+	</File>
+	<File name="Logging/CPULogger.h" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="283" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="PPU.h" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1999" topLine="163" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/MemoryMapper.h" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="271" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/UxROM.hpp" open="0" top="0" tabpos="17" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="271" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/CartDB.hpp" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="312" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/GxROM.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="44" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="APU.h" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="213" topLine="87" />
+		</Cursor>
+	</File>
+	<File name="Logging/CPULogger.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="7501" topLine="131" />
+		</Cursor>
+	</File>
+	<File name="Cartridge/Mappers/BasicMapper.hpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="543" topLine="3" />
+		</Cursor>
+	</File>
+	<File name="RetroAudio.hpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1001" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="Input.cpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1636" topLine="56" />
 		</Cursor>
 	</File>
 </CodeBlocks_layout_file>

--- a/RetroAudio.hpp
+++ b/RetroAudio.hpp
@@ -4,7 +4,7 @@
 #include <SDL2/SDL.h>
 #include <queue>
 #include <vector>
-
+#include <stdio.h>
 
 class RetroFraction
 {
@@ -22,6 +22,7 @@ private:
 
 class RetroAudio
 {
+    SDL_AudioDeviceID sdldev;
     const unsigned SAMPLING = 48000;
     const unsigned BUFFER_LENGTH = 2048;
 


### PR DESCRIPTION
At least my windows machine was giving a 32-bit audio device, retroAudio
was expecting 16-bit, now SDL will handle the difference.